### PR TITLE
Ajuste de descrição no README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ Este teste é confidencial, portanto não é autorizada a exibição ou envio po
 Você terá 7 dias para fazer o case.
 
 ### CASE:
-Automatize a criação de um ambiente na AWS com as seguintes especificações:
+Automatize a criação de um ambiente cloud (AWS - prefencialmente, ou Azure ou GCP) com as seguintes especificações:
 - O ambiente deve servir uma aplicação Python e uma aplicação PHP;
 - As aplicações devem responder numa URL pública;
 - A aplicação PHP pode ter sua saúde testada no path /ping;
 - A aplicação Python pode ter sua saúde testada no path /ping;
 - As aplicações de exemplo devem ser clonadas deste próprio [repositório git](https://github.com/meliuz/devops-apps), sendo que ambas possuem dependências para funcionar;
 - A aplicação php possui um arquivo .htaccess para funcionar como esperado;
-- Na aplicação PHP é necessário configurar uma variável de ambiente “PYTHON_APP_ADDRESS” com a URL pública da aplicação Python (o IP de um AWS EC2 ou qualquer outro endereço publicamente acessível, onde a aplicação esteja sendo servida);
+- Na aplicação PHP é necessário configurar uma variável de ambiente “PYTHON_APP_ADDRESS” com a URL pública da aplicação Python (o IP de uma instância ou qualquer outro endereço publicamente acessível, onde a aplicação esteja sendo servida);
 - A automação deverá realizar o deploy das aplicações disponíveis de forma automática;
 - O ambiente deve ser seguro a ataques externos (o mais seguro que você conseguir sem indisponibilizar as aplicações);
 - As aplicações devem estar configuradas para um scale up de uma máquina quando o grupo atingir mais de 70% do CPU por mais de 5 minutos;


### PR DESCRIPTION
Ajuste na descrição de qual cloud provider poderá ser utilizado no teste, deixando aberto a ser AWS, GCP ou Azure.